### PR TITLE
feat: implement initiate claim

### DIFF
--- a/src/InheritX.cairo
+++ b/src/InheritX.cairo
@@ -1,11 +1,12 @@
 #[starknet::contract]
 pub mod InheritX {
-    use starknet::ContractAddress;
     use starknet::storage::{
         Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess,
         StoragePointerWriteAccess,
     };
+    use starknet::{ContractAddress, get_caller_address, get_contract_address};
     use crate::interfaces::IInheritX::{AssetAllocation, IInheritX, InheritancePlan};
+    use crate::types::SimpleBeneficiary;
 
     #[storage]
     struct Storage {
@@ -30,22 +31,131 @@ pub mod InheritX {
         claimed_plans: u256,
         total_value_locked: u256,
         total_fees_collected: u256,
+        // Beneficiary to Recipient Mapping
+        funds: Map<u256, SimpleBeneficiary>,
+        plans_id: u256,
+        // Dummy Mapping For transfer
+        balances: Map<ContractAddress, u256>,
+        deployed: bool,
     }
+
 
     #[constructor]
-    fn constructor(ref self: ContractState, admin: ContractAddress) { // Initialize contract state:
-    // 1. Set admin address
-    // 2. Set default protocol parameters:
-    //    - protocol_fee = 50 (0.5%)
-    //    - min_guardians = 1
-    //    - max_guardians = 5
-    //    - min_timelock = 7 days
-    //    - max_timelock = 365 days
-    // 3. Initialize all statistics to 0
-    // 4. Set is_paused to false
+    fn constructor(ref self: ContractState) { // Initialize contract state:
+        // 1. Set admin address
+        // 2. Set default protocol parameters:
+        //    - protocol_fee = 50 (0.5%)
+        //    - min_guardians = 1
+        //    - max_guardians = 5
+        //    - min_timelock = 7 days
+        //    - max_timelock = 365 days
+        // 3. Initialize all statistics to 0
+        // 4. Set is_paused to false
+        self.deployed.write(true);
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl IInheritXImpl of IInheritX<ContractState> { // Contract Management Functions
+        // Initialize a new claim with a claim code
+        /// Initiates a claim for an inheritance plan by creating a new beneficiary entry
+        /// and processing the payout.
+        ///
+        /// @param name - The name of the beneficiary.
+        /// @param email - The email address of the beneficiary.
+        /// @param beneficiary - The wallet address of the beneficiary.
+        /// @param personal_message - A message associated with the inheritance.
+        /// @param amount - The amount allocated for the beneficiary.
+        /// @param claim_code - A unique code assigned to the claim.
+        /// @param amountt - (Unused) Duplicate of `amount`, consider removing if unnecessary.
+        /// @return felt252 - Returns `1` on successful claim initiation.
+        fn create_claim(
+            ref self: ContractState,
+            name: felt252,
+            email: felt252,
+            beneficiary: ContractAddress,
+            personal_message: felt252,
+            amount: u256,
+            claim_code: u256,
+        ) -> u256 {
+            let inheritance_id = self.plans_id.read(); // Use it before incrementing
+            // Create a new beneficiary record
+            let new_beneficiary = SimpleBeneficiary {
+                id: inheritance_id,
+                name,
+                email,
+                wallet_address: beneficiary,
+                personal_message,
+                amount,
+                code: claim_code, // Ensure type compatibility
+                claim_status: false,
+                benefactor: get_caller_address(),
+            };
+
+            // Store the beneficiary details in the `funds` mapping
+            self.funds.write(inheritance_id, new_beneficiary);
+
+            // Increment the plan ID after storing the new entry
+
+            self.plans_id.write(inheritance_id + 1);
+
+            // Transfer funds as part of the claim process
+            self.transfer_funds(get_contract_address(), amount);
+
+            // Return success code
+            inheritance_id
+        }
+        /// Allows a beneficiary to collect their claim.
+        /// @param self - The contract state.
+        /// @param inheritance_id - The ID of the inheritance claim.
+        /// @param beneficiary - The wallet address of the beneficiary.
+        /// @param claim_code - The unique code to verify the claim.
+        /// @returns `true` if the claim is successfully collected, otherwise `false`.
+        fn collect_claim(
+            ref self: ContractState,
+            inheritance_id: u256,
+            beneficiary: ContractAddress,
+            claim_code: u256,
+        ) -> bool {
+            // Retrieve the claim details from storage
+            let mut claim = self.funds.read(inheritance_id);
+
+            // Ensure the claim has not been collected before
+            assert(!claim.claim_status, 'You have already made a claim');
+
+            // Verify that the correct beneficiary is making the claim
+            assert((claim.wallet_address == beneficiary), 'Not your claim');
+
+            // Verify that the provided claim code matches the stored one
+            assert((claim.code == claim_code), 'Invalid claim code');
+
+            // Mark the claim as collected
+            claim.claim_status = true;
+
+            // Transfer the funds to the beneficiary
+            self.transfer_funds(beneficiary, claim.amount);
+
+            // Update the claim in storage after modifying it
+            self.funds.write(inheritance_id, claim);
+            // Return success status
+            true
+        }
+
+
+        // Dummy Functions
+        /// Retrieves the details of a claim using the inheritance ID.
+        /// @param self - The contract state.
+        /// @param inheritance_id - The ID of the inheritance claim.
+        /// @returns The `SimpleBeneficiary` struct containing the claim details.
+        fn retrieve_claim(ref self: ContractState, inheritance_id: u256) -> SimpleBeneficiary {
+            self.funds.read(inheritance_id)
+        }
+
+        fn transfer_funds(ref self: ContractState, beneficiary: ContractAddress, amount: u256) {
+            let current_bal = self.balances.read(beneficiary);
+            self.balances.write(beneficiary, current_bal + amount);
+        }
+        fn test_deployment(ref self: ContractState) -> bool {
+            self.deployed.read()
+        }
     }
 }

--- a/src/interfaces/IInheritX.cairo
+++ b/src/interfaces/IInheritX.cairo
@@ -1,5 +1,5 @@
 use starknet::ContractAddress;
-
+use crate::types::SimpleBeneficiary;
 #[derive(Copy, Drop, Serde, starknet::Store)]
 pub struct InheritancePlan {
     owner: ContractAddress,
@@ -18,4 +18,26 @@ pub struct AssetAllocation {
 }
 
 #[starknet::interface]
-pub trait IInheritX<TContractState> {}
+pub trait IInheritX<TContractState> {
+    // Initialize a new claim with a claim code
+    fn create_claim(
+        ref self: TContractState,
+        name: felt252,
+        email: felt252,
+        beneficiary: ContractAddress,
+        personal_message: felt252,
+        amount: u256,
+        claim_code: u256,
+    ) -> u256;
+
+    fn collect_claim(
+        ref self: TContractState,
+        inheritance_id: u256,
+        beneficiary: ContractAddress,
+        claim_code: u256,
+    ) -> bool;
+
+    fn retrieve_claim(ref self: TContractState, inheritance_id: u256) -> SimpleBeneficiary;
+    fn transfer_funds(ref self: TContractState, beneficiary: ContractAddress, amount: u256);
+    fn test_deployment(ref self: TContractState) -> bool;
+}

--- a/src/interfaces/IInheritXClaim.cairo
+++ b/src/interfaces/IInheritXClaim.cairo
@@ -10,6 +10,10 @@ pub trait IInheritXClaim<TContractState> {
         ref self: TContractState, plan_id: u256, beneficiary: ContractAddress, claim_code: u256,
     ) -> felt252;
 
+    // fn create_claim(
+    //     ref self: TContractState, plan_id: u256, beneficiary: ContractAddress, claim_code: u256,
+    // ) -> felt252;
+
     // Get all claims for a beneficiary
     fn get_beneficiary_claims(
         self: @TContractState, beneficiary: ContractAddress,

--- a/src/types.cairo
+++ b/src/types.cairo
@@ -107,13 +107,17 @@ pub struct NFTInfo {
     pub estimated_value: u256,
 }
 
-#[derive(Copy, Drop, Serde, starknet::Store)]
+#[derive(Drop, Serde, starknet::Store)]
 pub struct SimpleBeneficiary {
-    pub id: u32, // Unique identifier for the beneficiary
+    pub id: u256, // Unique identifier for the beneficiary
     pub name: felt252,
     pub email: felt252,
     pub wallet_address: ContractAddress,
     pub personal_message: felt252,
+    pub amount: u256,
+    pub code: u256,
+    pub claim_status: bool,
+    pub benefactor: ContractAddress,
 }
 
 #[derive(Drop, Serde)]

--- a/tests/test_claim.cairo
+++ b/tests/test_claim.cairo
@@ -1,13 +1,196 @@
-// // Import the contract modules
-// use inheritx::imple::InheritXClaim::InheritxClaim;
-// use inheritx::imple::InheritXPlan::InheritxPlan;
-// use inheritx::interfaces::IInheritXClaim::{
-//     IInheritXClaim, IInheritXClaimDispatcher, IInheritXClaimDispatcherTrait,
-// };
-// use snforge_std::{ContractClassTrait, DeclareResultTrait, declare};
-// use starknet::ContractAddress;
-// use starknet::class_hash::ClassHash;
-// use starknet::contract_address::contract_address_const;
-// use starknet::testing::{set_caller_address, set_contract_address};
+// Import the contract modules
+use inheritx::imple::InheritXClaim::InheritxClaim;
+use inheritx::imple::InheritXPlan::InheritxPlan;
+use inheritx::interfaces::IInheritX::{IInheritX, IInheritXDispatcher, IInheritXDispatcherTrait};
+use snforge_std::{ContractClassTrait, DeclareResultTrait, declare};
+use starknet::ContractAddress;
+use starknet::class_hash::ClassHash;
+use starknet::contract_address::contract_address_const;
+use starknet::testing::{set_caller_address, set_contract_address};
+use snforge_std::{cheat_caller_address, CheatSpan};
 
 
+
+fn setup() -> ContractAddress {
+    let declare_result = declare("InheritX");
+    assert(declare_result.is_ok(), 'Contract declaration failed');
+
+    let contract_class = declare_result.unwrap().contract_class();
+    let mut calldata = array![];
+
+    let deploy_result = contract_class.deploy(@calldata);
+    assert(deploy_result.is_ok(), 'Contract deployment failed');
+
+    let (contract_address, _) = deploy_result.unwrap();
+
+    (contract_address)
+}
+
+#[test]
+fn test_initial_data() {
+    let contract_address = setup();
+
+    let dispatcher = IInheritXDispatcher { contract_address };
+
+    // Ensure dispatcher methods exist
+    let deployed = dispatcher.test_deployment();
+
+    assert(deployed == true, 'deployment failed');
+}
+
+
+#[test]
+fn test_create_claim() {
+    let contract_address = setup();
+    let dispatcher = IInheritXDispatcher { contract_address };
+    let benefactor: ContractAddress = contract_address_const::<'benefactor'>();
+    let beneficiary: ContractAddress = contract_address_const::<'beneficiary'>();
+
+    // Test input values
+    let name: felt252 = 'John';
+    let email: felt252 = 'John@yahoo.com'; 
+    let personal_message = 'i love you my son';
+    let claim_code = 2563;
+
+    // Ensure the caller is the admin
+    cheat_caller_address(contract_address, benefactor, CheatSpan::Indefinite);
+
+    // Call create_claim
+    let claim_id = dispatcher.create_claim(name, email, beneficiary, personal_message, 1000, claim_code);
+
+    // Validate that the claim ID is correctly incremented
+    assert(claim_id == 0, 'claim ID should start from 0');
+
+    // Retrieve the claim to verify it was stored correctly
+    let claim = dispatcher.retrieve_claim(claim_id);
+    assert(claim.id == claim_id, 'claim ID mismatch');
+    assert(claim.name == name, 'claim title mismatch');
+    assert(claim.personal_message == personal_message, 'claim description mismatch');
+    assert(claim.code == claim_code, 'claim price mismatch');
+    assert(claim.wallet_address == beneficiary, 'cbenificiary address mismatch');
+    assert(claim.email == email, 'claim email mismatch');
+    assert(claim.benefactor == benefactor, 'benefactor address mismatch');
+}
+
+
+#[test]
+fn test_collect_claim() {
+    let contract_address = setup();
+    let dispatcher = IInheritXDispatcher { contract_address };
+    let benefactor: ContractAddress = contract_address_const::<'benefactor'>();
+    let beneficiary: ContractAddress = contract_address_const::<'beneficiary'>();
+
+    // Test input values
+    let name: felt252 = 'John';
+    let email: felt252 = 'John@yahoo.com'; 
+    let personal_message = 'i love you my son';
+    let claim_code = 2563;
+
+    // Ensure the caller is the admin
+    cheat_caller_address(contract_address, benefactor, CheatSpan::Indefinite);
+
+    // Call create_claim
+    let claim_id = dispatcher.create_claim(name, email, beneficiary, personal_message, 1000, claim_code);
+
+    // Validate that the claim ID is correctly incremented
+    assert(claim_id == 0, 'claim ID should start from 0');
+    cheat_caller_address(contract_address, beneficiary, CheatSpan::Indefinite);
+
+  let success = dispatcher.collect_claim(0, beneficiary, 2563);
+
+  assert(success, 'Claim unsuccessful');
+}
+
+#[test]
+#[should_panic(expected: 'Not your claim')]
+fn test_collect_claim_with_wrong_address() {
+    let contract_address = setup();
+    let dispatcher = IInheritXDispatcher { contract_address };
+    let benefactor: ContractAddress = contract_address_const::<'benefactor'>();
+    let beneficiary: ContractAddress = contract_address_const::<'beneficiary'>();
+    let malicious: ContractAddress = contract_address_const::<'malicious'>();
+
+    // Test input values
+    let name: felt252 = 'John';
+    let email: felt252 = 'John@yahoo.com'; 
+    let personal_message = 'i love you my son';
+    let claim_code = 2563;
+
+    // Ensure the caller is the admin
+    cheat_caller_address(contract_address, benefactor, CheatSpan::Indefinite);
+
+    // Call create_claim
+    let claim_id = dispatcher.create_claim(name, email, beneficiary, personal_message, 1000, claim_code);
+
+    // Validate that the claim ID is correctly incremented
+    assert(claim_id == 0, 'claim ID should start from 0');
+    cheat_caller_address(contract_address, beneficiary, CheatSpan::Indefinite);
+
+  let success = dispatcher.collect_claim(0, malicious, 2563);
+
+  assert(success, 'Claim unsuccessful');
+}
+
+#[test]
+#[should_panic(expected: 'Invalid claim code')]
+fn test_collect_claim_with_wrong_code() {
+    let contract_address = setup();
+    let dispatcher = IInheritXDispatcher { contract_address };
+    let benefactor: ContractAddress = contract_address_const::<'benefactor'>();
+    let beneficiary: ContractAddress = contract_address_const::<'beneficiary'>();
+    let malicious: ContractAddress = contract_address_const::<'malicious'>();
+
+    // Test input values
+    let name: felt252 = 'John';
+    let email: felt252 = 'John@yahoo.com'; 
+    let personal_message = 'i love you my son';
+    let claim_code = 2563;
+
+    // Ensure the caller is the admin
+    cheat_caller_address(contract_address, benefactor, CheatSpan::Indefinite);
+
+    // Call create_claim
+    let claim_id = dispatcher.create_claim(name, email, beneficiary, personal_message, 1000, claim_code);
+
+    // Validate that the claim ID is correctly incremented
+    assert(claim_id == 0, 'claim ID should start from 0');
+    cheat_caller_address(contract_address, beneficiary, CheatSpan::Indefinite);
+
+  let success = dispatcher.collect_claim(0, beneficiary, 63);
+
+  assert(success, 'Claim unsuccessful');
+
+  
+}
+
+#[test]
+#[should_panic(expected: 'You have already made a claim')]
+fn test_collect_claim_twice() {
+    let contract_address = setup();
+    let dispatcher = IInheritXDispatcher { contract_address };
+    let benefactor: ContractAddress = contract_address_const::<'benefactor'>();
+    let beneficiary: ContractAddress = contract_address_const::<'beneficiary'>();
+    let malicious: ContractAddress = contract_address_const::<'malicious'>();
+
+    // Test input values
+    let name: felt252 = 'John';
+    let email: felt252 = 'John@yahoo.com'; 
+    let personal_message = 'i love you my son';
+    let claim_code = 2563;
+
+    // Ensure the caller is the admin
+    cheat_caller_address(contract_address, benefactor, CheatSpan::Indefinite);
+
+    // Call create_claim
+    let claim_id = dispatcher.create_claim(name, email, beneficiary, personal_message, 1000, claim_code);
+
+    // Validate that the claim ID is correctly incremented
+    assert(claim_id == 0, 'claim ID should start from 0');
+    cheat_caller_address(contract_address, beneficiary, CheatSpan::Indefinite);
+
+  let success = dispatcher.collect_claim(0, beneficiary, 2563);
+
+  assert(success, 'Claim unsuccessful');
+
+  let success2 = dispatcher.collect_claim(0, beneficiary, 2563);
+}


### PR DESCRIPTION
implemented the create_claim function to register a new inheritance claim by storing beneficiary details, assigning a unique ID, and allocating the specified funds for future collection. Additionally, I implemented the collect_claim function to allow a verified beneficiary to retrieve their inheritance by verifying their wallet address and claim code. Once validated, the claim is marked as collected, and the allocated funds are transferred to the beneficiary’s wallet.
closes #6 