### PR TITLE
feat: Implement get_total_plans function and add unit tests

### DIFF
--- a/src/InheritX.cairo
+++ b/src/InheritX.cairo
@@ -99,8 +99,6 @@ pub mod InheritX {
 
             self.plans_id.write(inheritance_id + 1);
 
-
-
             // Increment the total plans count
             let total_plans = self.total_plans.read();
             self.total_plans.write(total_plans + 1);

--- a/src/InheritX.cairo
+++ b/src/InheritX.cairo
@@ -52,6 +52,7 @@ pub mod InheritX {
         // 3. Initialize all statistics to 0
         // 4. Set is_paused to false
         self.deployed.write(true);
+        self.total_plans.write(0); // Initialize total_plans to 0
     }
 
     #[abi(embed_v0)]
@@ -98,6 +99,12 @@ pub mod InheritX {
 
             self.plans_id.write(inheritance_id + 1);
 
+
+
+            // Increment the total plans count
+            let total_plans = self.total_plans.read();
+            self.total_plans.write(total_plans + 1);
+
             // Transfer funds as part of the claim process
             self.transfer_funds(get_contract_address(), amount);
 
@@ -136,6 +143,7 @@ pub mod InheritX {
 
             // Update the claim in storage after modifying it
             self.funds.write(inheritance_id, claim);
+
             // Return success status
             true
         }
@@ -156,6 +164,10 @@ pub mod InheritX {
         }
         fn test_deployment(ref self: ContractState) -> bool {
             self.deployed.read()
+        }
+
+        fn get_total_plans(self: @ContractState) -> u256 {
+            self.total_plans.read()
         }
     }
 }

--- a/src/interfaces/IInheritX.cairo
+++ b/src/interfaces/IInheritX.cairo
@@ -40,4 +40,5 @@ pub trait IInheritX<TContractState> {
     fn retrieve_claim(ref self: TContractState, inheritance_id: u256) -> SimpleBeneficiary;
     fn transfer_funds(ref self: TContractState, beneficiary: ContractAddress, amount: u256);
     fn test_deployment(ref self: TContractState) -> bool;
+    fn get_total_plans(self: @TContractState) -> u256;
 }

--- a/tests/test_claim.cairo
+++ b/tests/test_claim.cairo
@@ -2,13 +2,11 @@
 use inheritx::imple::InheritXClaim::InheritxClaim;
 use inheritx::imple::InheritXPlan::InheritxPlan;
 use inheritx::interfaces::IInheritX::{IInheritX, IInheritXDispatcher, IInheritXDispatcherTrait};
-use snforge_std::{ContractClassTrait, DeclareResultTrait, declare};
+use snforge_std::{CheatSpan, ContractClassTrait, DeclareResultTrait, cheat_caller_address, declare};
 use starknet::ContractAddress;
 use starknet::class_hash::ClassHash;
 use starknet::contract_address::contract_address_const;
 use starknet::testing::{set_caller_address, set_contract_address};
-use snforge_std::{cheat_caller_address, CheatSpan};
-
 
 
 fn setup() -> ContractAddress {
@@ -48,7 +46,7 @@ fn test_create_claim() {
 
     // Test input values
     let name: felt252 = 'John';
-    let email: felt252 = 'John@yahoo.com'; 
+    let email: felt252 = 'John@yahoo.com';
     let personal_message = 'i love you my son';
     let claim_code = 2563;
 
@@ -56,7 +54,8 @@ fn test_create_claim() {
     cheat_caller_address(contract_address, benefactor, CheatSpan::Indefinite);
 
     // Call create_claim
-    let claim_id = dispatcher.create_claim(name, email, beneficiary, personal_message, 1000, claim_code);
+    let claim_id = dispatcher
+        .create_claim(name, email, beneficiary, personal_message, 1000, claim_code);
 
     // Validate that the claim ID is correctly incremented
     assert(claim_id == 0, 'claim ID should start from 0');
@@ -82,7 +81,7 @@ fn test_collect_claim() {
 
     // Test input values
     let name: felt252 = 'John';
-    let email: felt252 = 'John@yahoo.com'; 
+    let email: felt252 = 'John@yahoo.com';
     let personal_message = 'i love you my son';
     let claim_code = 2563;
 
@@ -90,15 +89,16 @@ fn test_collect_claim() {
     cheat_caller_address(contract_address, benefactor, CheatSpan::Indefinite);
 
     // Call create_claim
-    let claim_id = dispatcher.create_claim(name, email, beneficiary, personal_message, 1000, claim_code);
+    let claim_id = dispatcher
+        .create_claim(name, email, beneficiary, personal_message, 1000, claim_code);
 
     // Validate that the claim ID is correctly incremented
     assert(claim_id == 0, 'claim ID should start from 0');
     cheat_caller_address(contract_address, beneficiary, CheatSpan::Indefinite);
 
-  let success = dispatcher.collect_claim(0, beneficiary, 2563);
+    let success = dispatcher.collect_claim(0, beneficiary, 2563);
 
-  assert(success, 'Claim unsuccessful');
+    assert(success, 'Claim unsuccessful');
 }
 
 #[test]
@@ -112,7 +112,7 @@ fn test_collect_claim_with_wrong_address() {
 
     // Test input values
     let name: felt252 = 'John';
-    let email: felt252 = 'John@yahoo.com'; 
+    let email: felt252 = 'John@yahoo.com';
     let personal_message = 'i love you my son';
     let claim_code = 2563;
 
@@ -120,15 +120,16 @@ fn test_collect_claim_with_wrong_address() {
     cheat_caller_address(contract_address, benefactor, CheatSpan::Indefinite);
 
     // Call create_claim
-    let claim_id = dispatcher.create_claim(name, email, beneficiary, personal_message, 1000, claim_code);
+    let claim_id = dispatcher
+        .create_claim(name, email, beneficiary, personal_message, 1000, claim_code);
 
     // Validate that the claim ID is correctly incremented
     assert(claim_id == 0, 'claim ID should start from 0');
     cheat_caller_address(contract_address, beneficiary, CheatSpan::Indefinite);
 
-  let success = dispatcher.collect_claim(0, malicious, 2563);
+    let success = dispatcher.collect_claim(0, malicious, 2563);
 
-  assert(success, 'Claim unsuccessful');
+    assert(success, 'Claim unsuccessful');
 }
 
 #[test]
@@ -142,7 +143,7 @@ fn test_collect_claim_with_wrong_code() {
 
     // Test input values
     let name: felt252 = 'John';
-    let email: felt252 = 'John@yahoo.com'; 
+    let email: felt252 = 'John@yahoo.com';
     let personal_message = 'i love you my son';
     let claim_code = 2563;
 
@@ -150,17 +151,16 @@ fn test_collect_claim_with_wrong_code() {
     cheat_caller_address(contract_address, benefactor, CheatSpan::Indefinite);
 
     // Call create_claim
-    let claim_id = dispatcher.create_claim(name, email, beneficiary, personal_message, 1000, claim_code);
+    let claim_id = dispatcher
+        .create_claim(name, email, beneficiary, personal_message, 1000, claim_code);
 
     // Validate that the claim ID is correctly incremented
     assert(claim_id == 0, 'claim ID should start from 0');
     cheat_caller_address(contract_address, beneficiary, CheatSpan::Indefinite);
 
-  let success = dispatcher.collect_claim(0, beneficiary, 63);
+    let success = dispatcher.collect_claim(0, beneficiary, 63);
 
-  assert(success, 'Claim unsuccessful');
-
-  
+    assert(success, 'Claim unsuccessful');
 }
 
 #[test]
@@ -174,7 +174,7 @@ fn test_collect_claim_twice() {
 
     // Test input values
     let name: felt252 = 'John';
-    let email: felt252 = 'John@yahoo.com'; 
+    let email: felt252 = 'John@yahoo.com';
     let personal_message = 'i love you my son';
     let claim_code = 2563;
 
@@ -182,15 +182,16 @@ fn test_collect_claim_twice() {
     cheat_caller_address(contract_address, benefactor, CheatSpan::Indefinite);
 
     // Call create_claim
-    let claim_id = dispatcher.create_claim(name, email, beneficiary, personal_message, 1000, claim_code);
+    let claim_id = dispatcher
+        .create_claim(name, email, beneficiary, personal_message, 1000, claim_code);
 
     // Validate that the claim ID is correctly incremented
     assert(claim_id == 0, 'claim ID should start from 0');
     cheat_caller_address(contract_address, beneficiary, CheatSpan::Indefinite);
 
-  let success = dispatcher.collect_claim(0, beneficiary, 2563);
+    let success = dispatcher.collect_claim(0, beneficiary, 2563);
 
-  assert(success, 'Claim unsuccessful');
+    assert(success, 'Claim unsuccessful');
 
-  let success2 = dispatcher.collect_claim(0, beneficiary, 2563);
+    let success2 = dispatcher.collect_claim(0, beneficiary, 2563);
 }

--- a/tests/test_get_total_plans.cairo
+++ b/tests/test_get_total_plans.cairo
@@ -1,0 +1,57 @@
+use inheritx::interfaces::IInheritX::{IInheritX, IInheritXDispatcher, IInheritXDispatcherTrait};
+use snforge_std::{ContractClassTrait, DeclareResultTrait, declare};
+use starknet::ContractAddress;
+use starknet::contract_address::contract_address_const;
+use snforge_std::{cheat_caller_address, CheatSpan};
+
+fn setup() -> ContractAddress {
+    let declare_result = declare("InheritX");
+    assert(declare_result.is_ok(), 'Contract declaration failed');
+
+    let contract_class = declare_result.unwrap().contract_class();
+    let mut calldata = array![];
+
+    let deploy_result = contract_class.deploy(@calldata);
+    assert(deploy_result.is_ok(), 'Contract deployment failed');
+
+    let (contract_address, _) = deploy_result.unwrap();
+
+    contract_address
+}
+
+#[test]
+fn test_get_total_plans_initial() {
+    let contract_address = setup();
+    let dispatcher = IInheritXDispatcher { contract_address };
+
+    // Ensure the initial total plans count is 0
+    let total_plans = dispatcher.get_total_plans();
+    assert(total_plans == 0, 'Initial total plans should be 0');
+}
+
+#[test]
+fn test_get_total_plans_after_creation() {
+    let contract_address = setup();
+    let dispatcher = IInheritXDispatcher { contract_address };
+    let benefactor: ContractAddress = contract_address_const::<'benefactor'>();
+    let beneficiary: ContractAddress = contract_address_const::<'beneficiary'>();
+
+    // Test input values
+    let name: felt252 = 'John';
+    let email: felt252 = 'John@yahoo.com'; 
+    let personal_message = 'i love you my son';
+    let claim_code = 2563;
+
+    // Ensure the caller is the admin
+    cheat_caller_address(contract_address, benefactor, CheatSpan::Indefinite);
+
+    // Call create_claim to create a new plan
+    let claim_id = dispatcher.create_claim(name, email, beneficiary, personal_message, 1000, claim_code);
+
+    // Validate that the claim ID is correctly incremented
+    assert(claim_id == 0, 'claim ID should start from 0');
+
+    // Check the total plans count after creating a new plan
+    let total_plans = dispatcher.get_total_plans();
+    assert(total_plans == 1, 'Total plans should be 1');
+}

--- a/tests/test_get_total_plans.cairo
+++ b/tests/test_get_total_plans.cairo
@@ -1,8 +1,7 @@
 use inheritx::interfaces::IInheritX::{IInheritX, IInheritXDispatcher, IInheritXDispatcherTrait};
-use snforge_std::{ContractClassTrait, DeclareResultTrait, declare};
+use snforge_std::{CheatSpan, ContractClassTrait, DeclareResultTrait, cheat_caller_address, declare};
 use starknet::ContractAddress;
 use starknet::contract_address::contract_address_const;
-use snforge_std::{cheat_caller_address, CheatSpan};
 
 fn setup() -> ContractAddress {
     let declare_result = declare("InheritX");
@@ -38,7 +37,7 @@ fn test_get_total_plans_after_creation() {
 
     // Test input values
     let name: felt252 = 'John';
-    let email: felt252 = 'John@yahoo.com'; 
+    let email: felt252 = 'John@yahoo.com';
     let personal_message = 'i love you my son';
     let claim_code = 2563;
 
@@ -46,7 +45,8 @@ fn test_get_total_plans_after_creation() {
     cheat_caller_address(contract_address, benefactor, CheatSpan::Indefinite);
 
     // Call create_claim to create a new plan
-    let claim_id = dispatcher.create_claim(name, email, beneficiary, personal_message, 1000, claim_code);
+    let claim_id = dispatcher
+        .create_claim(name, email, beneficiary, personal_message, 1000, claim_code);
 
     // Validate that the claim ID is correctly incremented
     assert(claim_id == 0, 'claim ID should start from 0');


### PR DESCRIPTION

## Description:
This PR introduces the `get_total_plans` function to retrieve the total number of inheritance plans in the system. The function returns the count as a `u256` value. Additionally, comprehensive unit tests have been added to ensure the functionality works as expected.

## Changes Included:
1. Added the `get_total_plans` function to the `IInheritX` interface and implemented it in the `InheritX` contract.
2. Updated the `create_claim` function to increment the `total_plans` counter when a new plan is created.
3. **Wrote unit tests to verify:**
      - The initial count of plans is `0`.
      - The `total_plans` counter increments correctly after creating a new plan.

## Testing:
All unit tests have been successfully executed and passed.
![Screenshot from 2025-03-23 15-01-40](https://github.com/user-attachments/assets/f1c6d8b0-7d6e-49aa-bb43-734bbe8ca315)
![Screenshot from 2025-03-23 15-01-50](https://github.com/user-attachments/assets/ddd9b862-87a4-4af5-bd69-0b56130a3337)

## Impact:
This feature provides a reliable way to track the total number of inheritance plans in the system, which is essential for analytics and monitoring.

## Why This PR Matters
- **Functionality:** Adds a critical feature to retrieve the total number of plans.
- **Testing:** Ensures the feature is robust and reliable with comprehensive unit tests.
- **Maintainability:** Follows best practices by separating interface and implementation.

## Related Issue
This PR closes #33 