### PR TITLE
feat: add_beneficiary and test

### DIFF
--- a/src/interfaces/IInheritXPlan.cairo
+++ b/src/interfaces/IInheritXPlan.cairo
@@ -85,8 +85,11 @@ pub enum PlanSection {
     MediaAndRecipients: (),
 }
 
+
 #[starknet::interface]
 pub trait IInheritXPlan<TContractState> {
+
+
     // Plan Overview Management
     fn get_plan_section(self: @TContractState, plan_id: u256, section: PlanSection) -> PlanOverview;
 


### PR DESCRIPTION
###  **Function to add a single beneficiary to a plan**
 The function creates a SimpleBeneficiary object and adds it to the specified plan. The implementation includes comprehensive test cases to ensure the functionality works as expected. The interface and code have been transferred to IInheritX.cairo and InheritX.cairo respectively.

### **Key Changes:**

New Function: Added a function add_beneficiary_to_plan to InheritX.cairo that takes the necessary parameters to create a SimpleBeneficiary object and adds it to the plan.

Interface Update: Updated IInheritX.cairo to include the new function signature.

Test Cases: Wrote all necessary test cases to cover various scenarios, including edge cases.

Code Transfer: Moved the interface and implementation to their respective files (IInheritX.cairo and InheritX.cairo).

