### PR TITLE
add_beneficiary and test

### DIFF
--- a/src/interfaces/IInheritX.cairo
+++ b/src/interfaces/IInheritX.cairo
@@ -41,4 +41,11 @@ pub trait IInheritX<TContractState> {
     fn transfer_funds(ref self: TContractState, beneficiary: ContractAddress, amount: u256);
     fn test_deployment(ref self: TContractState) -> bool;
     fn get_total_plans(self: @TContractState) -> u256;
+    fn add_beneficiary(
+        ref self: TContractState,
+        plan_id: u256,
+        name: felt252,
+        email: felt252,
+        address: ContractAddress,
+    ) -> felt252;
 }


### PR DESCRIPTION

This PR introduces a new function to add a single beneficiary to a plan. The function creates a SimpleBeneficiary object and adds it to the specified plan. The implementation includes comprehensive test cases to ensure the functionality works as expected. The interface and code have been transferred to IInheritX.cairo and InheritX.cairo respectively.

**### Key Changes:**

New Function: Added a function add_beneficiary_to_plan to InheritX.cairo that takes the necessary parameters to create a SimpleBeneficiary object and adds it to the plan.

Interface Update: Updated IInheritX.cairo to include the new function signature.

Test Cases: Wrote all necessary test cases to cover various scenarios, including edge cases.

Code Transfer: Moved the interface and implementation to their respective files (IInheritX.cairo and InheritX.cairo).

