### PR TITLE
feat: implement and test delete user profile #40

### DIFF
--- a/src/InheritX.cairo
+++ b/src/InheritX.cairo
@@ -137,7 +137,7 @@ pub mod InheritX {
                 let asset = tokens.at(i);
                 total_value += *asset.amount;
                 i += 1;
-            }
+            };
 
             // Generate new plan ID
             let plan_id = self.plans_id.read();
@@ -169,7 +169,7 @@ pub mod InheritX {
                 self.plan_assets.write((plan_id, asset_index), *tokens.at(i));
                 asset_index += 1;
                 i += 1;
-            }
+            };
             self.plan_asset_count.write(plan_id, asset_count.try_into().unwrap());
 
             // Store beneficiaries
@@ -181,7 +181,7 @@ pub mod InheritX {
                 self.is_beneficiary.write((plan_id, beneficiary), true);
                 beneficiary_index += 1;
                 i += 1;
-            }
+            };
             self.plan_beneficiaries_count.write(plan_id, beneficiary_count);
 
             // Update protocol statistics
@@ -198,7 +198,7 @@ pub mod InheritX {
                 let asset = tokens.at(i);
                 self.transfer_funds(get_contract_address(), *asset.amount);
                 i += 1;
-            }
+            };
 
             // Return the plan ID
             plan_id
@@ -485,7 +485,7 @@ pub mod InheritX {
                 activity_history.append(record);
 
                 current_index += 1;
-            }
+            };
 
             activity_history
         }

--- a/src/interfaces/IInheritX.cairo
+++ b/src/interfaces/IInheritX.cairo
@@ -100,4 +100,5 @@ pub trait IInheritX<TContractState> {
         profile_image: felt252,
     ) -> bool;
     fn get_profile(ref self: TContractState, address: ContractAddress) -> UserProfile;
+    fn delete_user_profile(ref self: TContractState, address: ContractAddress) -> bool;
 }

--- a/src/types.cairo
+++ b/src/types.cairo
@@ -157,6 +157,7 @@ pub struct WalletInfo {
 pub enum NotificationSettings {
     #[default]
     Default,
+    Nil,
     email_notifications,
     push_notifications,
     claim_alerts,
@@ -168,6 +169,7 @@ pub enum NotificationSettings {
 #[derive(Drop, Serde, starknet::Store, Default)]
 pub enum SecuritySettings {
     #[default]
+    Nil,
     Two_factor_enabled,
     recovery_email,
     backup_guardians,
@@ -179,6 +181,7 @@ pub enum SecuritySettings {
 #[derive(Drop, Serde, starknet::Store, Default)]
 pub enum VerificationStatus {
     #[default]
+    Nil,
     Unverified,
     PendingVerification,
     Verified,
@@ -232,4 +235,3 @@ pub struct ActivityRecord {
     pub ip_address: felt252,
     pub device_info: felt252,
 }
-

--- a/tests/test_claim.cairo
+++ b/tests/test_claim.cairo
@@ -224,3 +224,68 @@ fn test_collect_create_profile() {
     assert(new_profile.profile_image == image, ' Wrong image');
     assert(new_profile.address == caller, ' Wrong Owner');
 }
+
+
+#[test]
+fn test_delete_profile() {
+    let contract_address = setup();
+    let dispatcher = IInheritXDispatcher { contract_address };
+    let caller: ContractAddress = contract_address_const::<'benefactor'>();
+
+    // Test input values
+    let username: felt252 = 'John1234';
+    let email: felt252 = 'John@yahoo.com';
+    let fullname = 'John Doe';
+    let image = 'image';
+
+    // Ensure the caller is the admin
+    cheat_caller_address(contract_address, caller, CheatSpan::Indefinite);
+
+    // Call create_claim
+    let claim_id = dispatcher.create_profile(username, email, fullname, image);
+
+    // Validate that the claim ID is correctly incremented
+
+    cheat_caller_address(contract_address, caller, CheatSpan::Indefinite);
+    let success = dispatcher.delete_user_profile(caller);
+    assert(success, 'Deletion Failed');
+    let new_profile = dispatcher.get_profile(caller);
+
+    assert(new_profile.username == ' ', 'Wrong Username');
+    assert(new_profile.email == ' ', ' Wrong email');
+    assert(new_profile.full_name == ' ', ' Wrong fullname');
+    assert(new_profile.profile_image == ' ', ' Wrong image');
+}
+
+#[test]
+#[should_panic(expected: 'No right to delete')]
+fn test_non_authorized_delete_profile() {
+    let contract_address = setup();
+    let dispatcher = IInheritXDispatcher { contract_address };
+    let caller: ContractAddress = contract_address_const::<'benefactor'>();
+    let malicious: ContractAddress = contract_address_const::<'malicious'>();
+
+    // Test input values
+    let username: felt252 = 'John1234';
+    let email: felt252 = 'John@yahoo.com';
+    let fullname = 'John Doe';
+    let image = 'image';
+
+    // Ensure the caller is the admin
+    cheat_caller_address(contract_address, caller, CheatSpan::Indefinite);
+
+    // Call create_claim
+    let claim_id = dispatcher.create_profile(username, email, fullname, image);
+
+    // Validate that the claim ID is correctly incremented
+
+    cheat_caller_address(contract_address, malicious, CheatSpan::Indefinite);
+    let success = dispatcher.delete_user_profile(caller);
+    assert(success, 'Deletion Failed');
+    let new_profile = dispatcher.get_profile(caller);
+
+    assert(new_profile.username == ' ', 'Wrong Username');
+    assert(new_profile.email == ' ', ' Wrong email');
+    assert(new_profile.full_name == ' ', ' Wrong fullname');
+    assert(new_profile.profile_image == ' ', ' Wrong image');
+}


### PR DESCRIPTION
This PR adds functionality to delete a user's profile and ensures all associated data is removed properly. The implementation includes:

A new function to delete a user's profile
Removal of all profile-related data
Test cases to verify the deletion process
Code refactoring to move relevant logic into IInheritX.cairo and InheritX.cairo

Issue Reference
Closes https://github.com/skill-mind/InheritX-smart_contract/issues/40

<img width="427" alt="Screenshot 2025-03-28 at 11 03 48" src="https://github.com/user-attachments/assets/5c40e57d-89d7-4ed9-9996-c3f12890d381" />
