### PR TITLE
Feat: update security settings and test

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,0 @@
-scarb 2.11.3
-snforge 0.39.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+scarb 2.11.3
+snforge 0.39.0

--- a/src/InheritX.cairo
+++ b/src/InheritX.cairo
@@ -580,16 +580,17 @@ pub mod InheritX {
             true
         }
 
-        fn update_security_settings(ref self: ContractState, new_settings: SecuritySettings) -> bool {
+        fn update_security_settings(
+            ref self: ContractState, new_settings: SecuritySettings,
+        ) -> bool {
             let caller = get_caller_address();
             let mut profile = self.user_profiles.read(caller);
             assert(profile.address == caller, 'Profile does not exist');
             profile.security_settings = new_settings;
-            
+
             self.user_profiles.write(caller, profile);
 
             true
         }
     }
-
 }

--- a/src/InheritX.cairo
+++ b/src/InheritX.cairo
@@ -579,5 +579,17 @@ pub mod InheritX {
 
             true
         }
+
+        fn update_security_settings(ref self: ContractState, new_settings: SecuritySettings) -> bool {
+            let caller = get_caller_address();
+            let mut profile = self.user_profiles.read(caller);
+            assert(profile.address == caller, 'Profile does not exist');
+            profile.security_settings = new_settings;
+            
+            self.user_profiles.write(caller, profile);
+
+            true
+        }
     }
+
 }

--- a/src/interfaces/IInheritX.cairo
+++ b/src/interfaces/IInheritX.cairo
@@ -1,9 +1,7 @@
 use starknet::ContractAddress;
-
 use crate::types::{
     ActivityRecord, ActivityType, NotificationSettings, NotificationStruct, PlanOverview,
-    PlanSection, SimpleBeneficiary, TokenInfo, UserProfile, SecuritySettings,
-
+    PlanSection, SecuritySettings, SimpleBeneficiary, TokenInfo, UserProfile,
 };
 
 #[derive(Copy, Drop, Serde, starknet::Store)]

--- a/src/interfaces/IInheritX.cairo
+++ b/src/interfaces/IInheritX.cairo
@@ -1,7 +1,7 @@
 use starknet::ContractAddress;
 use crate::types::{
-    ActivityRecord, ActivityType, NotificationSettings, NotificationStruct, SimpleBeneficiary,
-    UserProfile, SecuritySettings,
+    ActivityRecord, ActivityType, NotificationSettings, NotificationStruct, SecuritySettings,
+    SimpleBeneficiary, UserProfile,
 };
 
 #[derive(Copy, Drop, Serde, starknet::Store)]

--- a/src/interfaces/IInheritX.cairo
+++ b/src/interfaces/IInheritX.cairo
@@ -1,7 +1,7 @@
 use starknet::ContractAddress;
 use crate::types::{
     ActivityRecord, ActivityType, NotificationSettings, NotificationStruct, SimpleBeneficiary,
-    UserProfile,
+    UserProfile, SecuritySettings,
 };
 
 #[derive(Copy, Drop, Serde, starknet::Store)]
@@ -127,4 +127,6 @@ pub trait IInheritX<TContractState> {
     ) -> NotificationStruct;
 
     fn delete_user_profile(ref self: TContractState, address: ContractAddress) -> bool;
+
+    fn update_security_settings(ref self: TContractState, new_settings: SecuritySettings) -> bool;
 }

--- a/src/types.cairo
+++ b/src/types.cairo
@@ -166,11 +166,12 @@ pub enum NotificationSettings {
     marketing_updates,
 }
 
-#[derive(Drop, Serde, starknet::Store, Default)]
+#[derive(Drop, Serde, starknet::Store, Default, PartialEq)]
 pub enum SecuritySettings {
     #[default]
     Nil,
     Two_factor_enabled,
+    Two_factor_disabled,
     recovery_email,
     backup_guardians,
     auto_lock_period,

--- a/tests/test_inheritx.cairo
+++ b/tests/test_inheritx.cairo
@@ -4,7 +4,6 @@ mod tests {
     use inheritx::interfaces::IInheritX::{
         AssetAllocation, IInheritX, IInheritXDispatcher, IInheritXDispatcherTrait,
     };
-
     use inheritx::types::{ActivityType, SecuritySettings};
     use snforge_std::{
         CheatSpan, ContractClassTrait, DeclareResultTrait, EventSpyAssertionsTrait,

--- a/tests/test_inheritx.cairo
+++ b/tests/test_inheritx.cairo
@@ -4,12 +4,10 @@ mod tests {
     use inheritx::interfaces::IInheritX::{
         AssetAllocation, IInheritX, IInheritXDispatcher, IInheritXDispatcherTrait,
     };
-    
     use inheritx::types::{
         ActivityType, MediaMessage, PlanConditions, PlanOverview, PlanSection, PlanStatus,
-        SimpleBeneficiary, TokenInfo, UserProfile, SecuritySettings,
+        SecuritySettings, SimpleBeneficiary, TokenInfo, UserProfile,
     };
-
     use snforge_std::{
         CheatSpan, ContractClassTrait, DeclareResultTrait, EventSpyAssertionsTrait,
         cheat_caller_address, declare, spy_events, start_cheat_caller_address,

--- a/tests/test_inheritx.cairo
+++ b/tests/test_inheritx.cairo
@@ -5,7 +5,7 @@ mod tests {
         AssetAllocation, IInheritX, IInheritXDispatcher, IInheritXDispatcherTrait,
     };
 
-    use inheritx::types::{ActivityType,SecuritySettings,};
+    use inheritx::types::{ActivityType, SecuritySettings};
     use snforge_std::{
         CheatSpan, ContractClassTrait, DeclareResultTrait, EventSpyAssertionsTrait,
         cheat_caller_address, declare, spy_events, start_cheat_caller_address,
@@ -314,36 +314,41 @@ mod tests {
 
     #[test]
     fn test_update_security_settings() {
-        let (IInheritXDispatcher,contract_address) = setup();
+        let (IInheritXDispatcher, contract_address) = setup();
         let user = contract_address_const::<'user'>();
 
-        
         start_cheat_caller_address(contract_address, user);
-        IInheritXDispatcher.create_profile('username', 'email@example.com', 'Full Name', 'image_url');
+        IInheritXDispatcher
+            .create_profile('username', 'email@example.com', 'Full Name', 'image_url');
 
         // Check initial security settings
         let profile = IInheritXDispatcher.get_profile(user);
-        assert(profile.security_settings == SecuritySettings::Two_factor_enabled, 'initial settings incorrect');
+        assert(
+            profile.security_settings == SecuritySettings::Two_factor_enabled,
+            'initial settings incorrect',
+        );
 
         // Update security settings to Two_factor_disabled
         IInheritXDispatcher.update_security_settings(SecuritySettings::Two_factor_disabled);
 
         // Check updated settings
         let updated_profile = IInheritXDispatcher.get_profile(user);
-        assert(updated_profile.security_settings == SecuritySettings::Two_factor_disabled, 'settings not updated');
+        assert(
+            updated_profile.security_settings == SecuritySettings::Two_factor_disabled,
+            'settings not updated',
+        );
     }
 
     #[test]
     #[should_panic(expected: ('Profile does not exist',))]
     fn test_update_security_settings_no_profile() {
-        let (IInheritXDispatcher,contract_address) = setup();
+        let (IInheritXDispatcher, contract_address) = setup();
         let user = contract_address_const::<'user'>();
 
         // Try to update settings without creating profile
         start_cheat_caller_address(contract_address, user);
 
         IInheritXDispatcher.update_security_settings(SecuritySettings::Two_factor_disabled);
-
     }
     #[test]
     fn test_create_plan_without_profile() {
@@ -351,27 +356,19 @@ mod tests {
         let user = 'user'.try_into().unwrap();
         let token_address = 'token_contract'.try_into().unwrap();
         let beneficiary = 'beneficiary'.try_into().unwrap();
-    
+
         // Valid inputs
         let assets = array![
-            AssetAllocation {
-                token: token_address,
-                amount: 1000,
-                percentage: 100
-            }
+            AssetAllocation { token: token_address, amount: 1000, percentage: 100 },
         ];
         let beneficiaries = array![beneficiary];
-    
+
         // Set caller
         start_cheat_caller_address(contract_address, user);
         // Create plan without a profile
-        let plan_id = IInheritXDispatcher.create_inheritance_plan(
-            'user_plan',
-            assets,
-            'user plan description',
-            beneficiaries
-        );
-    
+        let plan_id = IInheritXDispatcher
+            .create_inheritance_plan('user_plan', assets, 'user plan description', beneficiaries);
+
         // Verify the plan was created
         let plan = IInheritXDispatcher.get_inheritance_plan(plan_id);
         assert(plan.is_active, 'Plan should be active');
@@ -383,7 +380,7 @@ mod tests {
     #[test]
     #[should_panic(expected: ('Not your claim',))]
     fn test_claim_without_profile() {
-        let (IInheritXDispatcher,contract_address) = setup();
+        let (IInheritXDispatcher, contract_address) = setup();
         let user = 'user'.try_into().unwrap();
 
         start_cheat_caller_address(contract_address, user);


### PR DESCRIPTION
# Implementing and Testing `update_security_settings` in InheritX Contract

This solution addresses the implementation of the `update_security_settings` function in the InheritX StarkNet contract, ensuring it updates and stores a user's security configuration, with full test coverage. The interface and implementation were seamlessly integrated into `IInheritX.cairo` and `InheritX.cairo`, respectively.

---

## 🛠️ What Was Solved  
### ✅ **Functionality**  
- Added `update_security_settings` to update a user's security settings (e.g., toggling two-factor authentication), with a check to ensure the caller has an existing profile.

### ✅ **Storage**  
- Persisted the updated security settings in the `user_profiles` mapping, leveraging the `UserProfile` struct's `security_settings` field.

### ✅ **Test Cases**  
- Developed comprehensive tests to verify:  
    - Successful updates for users with profiles  
    - Failure for users without profiles  

### ✅ **Code Integration**  
- Transferred the function's interface to `IInheritX.cairo` and its implementation to `InheritX.cairo`, ensuring consistency with the existing contract structure.

---

## 📌 Key Details  
### 🔹 **Implementation**  
- The function:  
    - Retrieves the caller's profile  
    - Validates its existence  
    - Updates the `security_settings`  
    - Stores the modified profile in the `user_profiles` mapping  

### 🔹 **Storage**  
- Uses the existing `Map<ContractAddress, UserProfile>` in the contract’s storage  
- `SecuritySettings` defined in `types.cairo` (enhanced with `PartialEq` for testing)  

### 🔹 **Tests**  
Two Cairo test cases in `tests/test_inheritx.cairo`:  
1. **Success case**  
    - Creates a profile  
    - Updates settings from `Two_factor_enabled` to `Two_factor_disabled`  
    - Verifies the change  

2. **Failure case**  
    - Attempts an update without a profile  
    - Expects a `'Profile does not exist'` panic  

---

## 📂 File Updates  
- **IInheritX.cairo**  
    - Added the `update_security_settings` function signature to the interface  

- **InheritX.cairo**  
    - Implemented the function within the `IInheritXImpl` block, alongside related profile management functions  

---

This solution ensures **robust functionality**, **persistent storage**, and **thorough testing** without altering unrelated contract logic, aligning with the requirement to focus on `update_security_settings`.


This closes #45 
@GoSTEAN 