### PR TITLE
feat: implement verification and claim with Poseidon hash

### DIFF
--- a/src/interfaces/IInheritX.cairo
+++ b/src/interfaces/IInheritX.cairo
@@ -28,7 +28,6 @@ pub trait IInheritX<TContractState> {
         beneficiary: ContractAddress,
         personal_message: felt252,
         amount: u256,
-        claim_code: u256,
     ) -> u256;
 
     fn create_profile(
@@ -112,6 +111,13 @@ pub trait IInheritX<TContractState> {
     fn get_total_plans(self: @TContractState) -> u256;
 
     fn generate_recovery_code(ref self: TContractState, user: ContractAddress) -> felt252;
+
+    fn generate_claim_code(
+        ref self: TContractState,
+        beneficiary: ContractAddress,
+        benefactor: ContractAddress,
+        amount: u256,
+    ) -> felt252;
 
     fn initiate_recovery(
         ref self: TContractState, user: ContractAddress, recovery_method: felt252,


### PR DESCRIPTION
Closes #112 

- [x] Replaced hardcoded verification codes with Poseidon-based secure generation
- [x] Added `generate_claim_code()` function for Poseidon-based claim code generation
- [x] Updated `create_claim()` to automatically generate secure codes instead of accepting user input
- [x] Removed `claim_code` parameter from `create_claim()` interface for cleaner API
- [x] Added `VerificationData` and `ClaimData` structs for structured Poseidon hashing
- [x] Updated all verification and claim tests to work with generated Poseidon codes
- [x] Added 3 new tests specifically for Poseidon claim code functionality
- [x] Ensured consistent Poseidon usage across all verification/recovery/claim systems

<img width="1137" height="930" alt="inherit" src="https://github.com/user-attachments/assets/b7fd1a91-3e5d-43dd-83d8-9bde1e98f810" />
